### PR TITLE
convert MBR, VBR, & Stage2 to use a BSS section.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ stage2: $(stage2_binary_files)
 boottest: $(boottest_binary_files)
 
 clean:
+	@rm -rvf *.map
 	@rm -rvf $(build_dir)/*
 	@rm -rvf $(iso)
 	@rm -rvf $(isoz)

--- a/include/BIOS/func/E820_memory_map.nasm
+++ b/include/BIOS/func/E820_memory_map.nasm
@@ -48,7 +48,8 @@ GetMemoryMap:
     mov eax, 0xE820                         ; select 0xE820 function
     xor ebx, ebx                            ; Continuation value, 0 for the first call
 
-    mov dx, (BIOSMemoryMap >> 4)
+    lea dx, [BIOSMemoryMap]
+    shr dx, 4
     mov es, dx
     xor di, di                              ; (BIOSMemoryMap >> 4):0 makes di an index into BIOSMemoryMap
 

--- a/include/BIOS/func/ext_read.nasm
+++ b/include/BIOS/func/ext_read.nasm
@@ -36,6 +36,29 @@ struc LBAPkt_t
     .lower_lba   resd 1
     .upper_lba   resd 1
 endstruc
+; call_read_disk_raw <word segment> <word offset> <dword lba> <word count> <word drive_num>
+%macro call_read_disk_raw 5
+    movzx ax, %5
+    push ax                                            ; drive_num
+
+    movzx ax, %4
+    push ax                                            ; count
+
+    movzx dword eax, %3
+    push dword eax                                     ; lba
+
+    movzx ax, %2
+    push ax                                            ; offset
+
+    movzx ax, %1
+    push ax                                            ; segment = 0
+
+    ; uint8_t read_stage2_raw(uint16_t buf_segment, uint16_t buf_offset, 
+    ;                         uint32_t lba,
+    ;                         uint16_t count, uint16_t drive_num)
+    call read_disk_raw
+    add sp, 0xC
+%endmacro
 
 ; Wrapper for AH=0x42 INT13h (Extended Read)
 ;

--- a/include/config.inc
+++ b/include/config.inc
@@ -21,7 +21,7 @@
 %ifndef __INC_STEVIA_CONFIG
 
 %define SECTOR_SIZE             512
-%define STAGE2_SECTOR_COUNT    0x40
+%define STAGE2_SECTOR_COUNT    0x30
 ; 32 KiB
 %define MAX_STAGE2_BYTES      (SECTOR_SIZE * STAGE2_SECTOR_COUNT)
 

--- a/include/early_mem.inc
+++ b/include/early_mem.inc
@@ -43,28 +43,6 @@
 ; 0x0000000100000000  	    ???	            ??? (whatever exists) 	    RAM -- free for use (PAE/64bit)/More Extended memory
 ; ???????????????? 	        ??? 	        ??? 	                    Potentially usable for memory mapped PCI devices in modern hardware (but typically not, due to backward compatibility) 
 
-; copy of partition table, 72 bytes
-%define partition_table       0x3000
-%define partition_table_SIZE  72
-
-; copy of FAT32 BPB, 33 bytes (+1 to the next value to align to uint16_t)
-;0x3048
-%define fat32_bpb             0x304A
-%define fat32_bpb_SIZE        36
-
-; copy of FAT32 EBPB, 54 bytes
-;0x306A
-%define fat32_ebpb            0x306E
-%define fat32_ebpb_SIZE       54
-
-
-; next free space is 0x32D0
-%define fat32_nc_data         0x35D0
-%define fat32_nc_data_SIZE    16
-
-; lba_packet for raw_disk_read
-%define lba_packet            0x4000
-
 ;PhysicalAddress = Segment * 16 + Offset
 %define SEG_TO_LINEAR(s,o) ((s << 4) + o)
 

--- a/include/early_mem.inc
+++ b/include/early_mem.inc
@@ -18,7 +18,7 @@
 ; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ; SOFTWARE.
 
-%ifndef __INC_MEM
+%ifndef __INC_EARLY_MEM
 
 
 ; ## Generic Low mem map (from osdev wiki) ##
@@ -60,12 +60,10 @@
 
 ; next free space is 0x32D0
 %define fat32_nc_data         0x35D0
-%define fat32_nc_data_size    16
+%define fat32_nc_data_SIZE    16
 
 ; lba_packet for raw_disk_read
 %define lba_packet            0x4000
-
-
 
 ;PhysicalAddress = Segment * 16 + Offset
 %define SEG_TO_LINEAR(s,o) ((s << 4) + o)
@@ -76,21 +74,5 @@
 ; Seg = (physical - offset) / 16
 %define LINEAR_TO_SEGMENT(p,o) ((p - o) >> 4)
 
-; create normalized linear addres from seg:off (16:4)
-; Segement = linear >> 4 (top 16 bits)
-; offset = linear & 0x0F (low 4 bits)
-
-struc EarlyBootStruct_t
-    .lba_packet_offset resw 1
-endstruc
-
-; 20 bytes, passed to loaded kernel
-struc SteviaInfoStruct_t
-    .MemoryMapPtr      resd 1
-    .MemoryMapEntries  resd 1
-    .BPBDataPtr        resd 1
-    .EBPBDataPtr       resd 1
-endstruc
-
 %endif
-%define __INC_MEM
+%define __INC_EARLY_MEM

--- a/include/entry.inc
+++ b/include/entry.inc
@@ -22,7 +22,7 @@
 
 ; 8KiB from 0x2500 -> 0x500
 %define EARLY_STACK_START            0x2500
-%define MBR_ENTRY                    0x7A00
+%define MBR_ENTRY                    0x0600
 %define VBR_ENTRY                    0x7C00
 %define STAGE2_ENTRY                 0x7E00
 

--- a/include/entry.inc
+++ b/include/entry.inc
@@ -21,10 +21,10 @@
 %ifndef __INC_ENTRY
 
 ; 8KiB from 0x2500 -> 0x500
-%define EARLY_STACK_START            0x2500
+%define EARLY_STACK_START            0xFFFF
 %define MBR_ENTRY                    0x0600
 %define VBR_ENTRY                    0x7C00
-%define STAGE2_ENTRY                 0x7E00
+%define STAGE2_ENTRY                 0x0500
 
 %endif
 %define __INC_ENTRY

--- a/include/fat32/FAT32_SYS.inc
+++ b/include/fat32/FAT32_SYS.inc
@@ -28,7 +28,7 @@ ALIGN 4, db 0x90
 InitFATDriver:
     __CDECL16_ENTRY
 .func:
-    mov ax, fat32_state_SIZE
+    mov ax, FAT32_State_t_size
     push ax                     ; length of fat32_state structure
     xor ax, ax
     push ax                     ; init fat32_state with zero

--- a/include/fat32/fat32_structures.inc
+++ b/include/fat32/fat32_structures.inc
@@ -63,6 +63,7 @@
 ;                           resulting in a value which does not fit in the Number of Sectors entry at 0x13. 
 
 struc FAT32_bpb_t
+    .reserved_init             resb 3
     .ident_8                   resb 8
     .bytes_per_sector_16       resb 2
     .sectors_per_cluster_8     resb 1

--- a/include/mem.inc
+++ b/include/mem.inc
@@ -43,13 +43,6 @@
 ; 0x0000000100000000  	    ???	            ??? (whatever exists) 	    RAM -- free for use (PAE/64bit)/More Extended memory
 ; ???????????????? 	        ??? 	        ??? 	                    Potentially usable for memory mapped PCI devices in modern hardware (but typically not, due to backward compatibility) 
 
-; 0x2700 -> 0x28FF
-%define disk_buffer           0x2700
-; 0x2900 -> 0x2AFF
-%define fat_buffer            0x2900
-; 0x2B00 -> 0x2CFF
-%define dir_buffer            0x2B00
-
 ; copy of partition table, 72 bytes
 %define partition_table       0x3000
 %define partition_table_SIZE  72
@@ -64,15 +57,6 @@
 %define fat32_ebpb            0x306E
 %define fat32_ebpb_SIZE       54
 
-; FAT32 FSInfo, 512 bytes
-;0x30A2
-%define fat32_fsinfo          0x30B0
-%define fat32_fsinfo_SIZE     512
-
-; some stored state for the fat32 driver
-;0x32A2
-%define fat32_state           0x34B0
-%define fat32_state_SIZE      32
 
 ; next free space is 0x32D0
 %define fat32_nc_data         0x35D0
@@ -81,14 +65,6 @@
 ; lba_packet for raw_disk_read
 %define lba_packet            0x4000
 
-%define BIOSMemoryMap         0x4200
-%define SteviaInfo            0x5200
-
-
-; High memory addresses for loading kernel (for use with unreal mode and 32bit override)
-
-; file load buffer at 16MB
-%define HMEM_load_buffer      0x1000000
 
 
 ;PhysicalAddress = Segment * 16 + Offset
@@ -103,6 +79,10 @@
 ; create normalized linear addres from seg:off (16:4)
 ; Segement = linear >> 4 (top 16 bits)
 ; offset = linear & 0x0F (low 4 bits)
+
+struc EarlyBootStruct_t
+    .lba_packet_offset resw 1
+endstruc
 
 ; 20 bytes, passed to loaded kernel
 struc SteviaInfoStruct_t

--- a/include/partition_table.inc
+++ b/include/partition_table.inc
@@ -34,15 +34,15 @@ struc PartEntry_t
     .chs_start  resb 3
     .part_type  resb 1
     .chs_end    resb 3
-    .lba_start  resb 4
-    .lba_length resb 4
+    .lba_start  resd 1
+    .lba_length resd 1
 endstruc
 
 struc PartTable_t
-    .partition1 resb 16
-    .partition2 resb 16
-    .partition3 resb 16
-    .partition4 resb 16
+    .partition1 resb PartEntry_t_size
+    .partition2 resb PartEntry_t_size
+    .partition3 resb PartEntry_t_size
+    .partition4 resb PartEntry_t_size
 endstruc
 
 %endif

--- a/include/util/error_func.nasm
+++ b/include/util/error_func.nasm
@@ -22,9 +22,7 @@
 
 %macro ERROR 1
     mov al, %1           ; al = 1 byte error code mapped to ascii values
-    db 0xEA              ; jmp far imm16:imm16
-    dw error             ; error_far_seg
-    dw 0x0000            ; error_far_ptr
+    jmp error
 %endmacro
 
 ; pass error as ascii character in al, errors a-zA-Z or 0-9

--- a/include/util/kmemcpy5_func.nasm
+++ b/include/util/kmemcpy5_func.nasm
@@ -28,7 +28,7 @@ kmemcpy5:
     __CDECL16_ENTRY
     push ds
     push es
-.setup_segments
+.setup_segments:
     mov ax, [bp + 4]
     mov ds, ax              ; destination segment
 
@@ -48,6 +48,6 @@ kmemcpy5:
 .endf:
     __CDECL16_EXIT
     ret
-    
+
 %define __INC_KMEMCPY5_FUNC
 %endif

--- a/include/util/kmemcpy5_func.nasm
+++ b/include/util/kmemcpy5_func.nasm
@@ -1,0 +1,53 @@
+; Copyright (c) 2024 Elaina Claus
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in all
+; copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+; SOFTWARE.
+
+%ifndef __INC_KMEMCPY5_FUNC
+%include 'cdecl16.inc'
+
+; uint8_t* kmemset(word dest_segment, word dest, word src_segment, word src, byte len);
+; not overlap safe, only for
+ALIGN 4, db 0x90
+kmemcpy5:
+    __CDECL16_ENTRY
+    push ds
+    push es
+.setup_segments
+    mov ax, [bp + 4]
+    mov ds, ax              ; destination segment
+
+    mov ax, [ bp + 8]
+    mov es, ax              ; source segment
+.func:
+    mov cx, [bp + 12]        ; len
+    mov si, [bp + 10]        ; src
+    mov di, [bp + 6]        ; dest
+    
+    cld                     ; ensure we are incrementing
+    rep movsb               ; move ds:si -> es:di
+    mov ax, di              ; return pointer to dest
+.restore_segments:
+    pop es
+    pop ds
+.endf:
+    __CDECL16_EXIT
+    ret
+    
+%define __INC_KMEMCPY5_FUNC
+%endif

--- a/include/util/kmemset4_func.nasm
+++ b/include/util/kmemset4_func.nasm
@@ -1,0 +1,47 @@
+; Copyright (c) 2024 Elaina Claus
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in all
+; copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+; SOFTWARE.
+
+%ifndef __INC_KMEMSET4_FUNC
+%include 'cdecl16.inc'
+
+; word kmemset_byte(word segment, word dst, byte val, word len);
+ALIGN 4, db 0x90
+kmemset4:
+    __CDECL16_ENTRY
+.setup_segment:
+    push es
+    mov ax, [bp + 4]
+    mov es, ax
+ .func:
+    mov     cx, [bp + 10]       ; size_t len
+    mov     al, [bp + 8]        ; uint8_t val
+    mov     di, [bp + 6]        ; word dst
+
+    cld
+    rep     stosb               ; move al -> es:di
+    mov     ax, di              ; return pointer to dest
+.restore_segments:
+    pop es
+.endf:
+    __CDECL16_EXIT
+    ret
+
+%endif
+%define __INC_KMEMSET4_FUNC

--- a/src/mbr/mbr.nasm
+++ b/src/mbr/mbr.nasm
@@ -19,7 +19,7 @@
 ; SOFTWARE.
 
 [BITS 16]
-[ORG 0x7A00]
+[ORG 0x0600]
 [CPU KATMAI]
 [WARNING -reloc-abs-byte]
 [WARNING -reloc-abs-word]                   ; Yes, we use absolute addresses. surpress these warnings.

--- a/src/mbr/mbr.nasm
+++ b/src/mbr/mbr.nasm
@@ -42,16 +42,18 @@ nop
 
 ALIGN 4
 init:
-    cli                         ; We do not want to be interrupted
+    cli                             ; We do not want to be interrupted
 
-    xor ax, ax                  ; 0 AX
-    mov ds, ax                  ; Set segment registers to 0
+    xor ax, ax                      ; 0 AX
+    mov ds, ax                      ; Set segment registers to 0
+    mov es, ax
+    
+    mov ss, ax                      ; Set Stack Segment to 0
+    mov sp, EARLY_STACK_START       ; Setup stack
+    mov bp, sp                      ; base ptr = stack ptr
+    sub sp, 0x10                    ; local varible space             
 
-    mov ss, ax                  ; Set Stack Segment to 0
-    mov sp, EARLY_STACK_START   ; Setup stack
-    mov bp, sp                  ; base ptr = stack ptr
-    sub sp, 0x20                ; local varible space             
-
+    xor cx, cx
     mov ch, 0x01                    ; 256 WORDs in MBR (512 bytes), 0x0100 in cx
     mov si, 0x7C00                  ; Current MBR Address (loaded here by BIOS)
     mov di, MBR_ENTRY               ; New MBR Address (our new relocation address)
@@ -115,12 +117,11 @@ main:
         mov dword eax, dword [bx + PartEntry_t.lba_start]
         push dword eax                                     ; lba
 
-        xor ax, ax
-        push ax                                            ; offset = 0
-
         mov ax, VBR_ENTRY
-        shr ax, 4
-        push ax                                            ; segment = 7C0
+        push ax                                            ; offset = 0x7c00
+
+        xor ax, ax
+        push ax                                            ; segment = 0
 
         ; uint8_t read_stage2_raw(uint16_t buf_segment, uint16_t buf_offset, 
         ;                         uint32_t lba,

--- a/src/mbr/mbr.nasm
+++ b/src/mbr/mbr.nasm
@@ -51,20 +51,13 @@ init:
 
     ;
     ; Zero BSS section
-    ;
-    mov cx, (end_bss - begin_bss)     ; count = bss length
-
+    mov cx, (end_bss - begin_bss)     ; count = bss length                    
     mov ax, begin_bss
-    shr ax, 4
-    mov es, ax                        ; es = begining of bss section
-
+    mov di, ax                        ; es:di is dest
     xor ax, ax
-    mov di, ax                        ; dst = 0
-
     cld
     rep stosb                         ; zero bss section
 
-    xor ax, ax
     mov ss, ax                      ; Set Stack Segment to 0
     mov sp, stack_top               ; Setup stack
     mov bp, sp                      ; base ptr = stack ptr

--- a/src/mbr/mbr.nasm
+++ b/src/mbr/mbr.nasm
@@ -161,6 +161,7 @@ main:
 
         mov si, word [bp - 4]
         mov dl, byte [bp - 2]
+        mov bx, partition_table
         jmp word 0x0000:0x7C00
 
 ; ###############

--- a/src/mbr/mbr.nasm
+++ b/src/mbr/mbr.nasm
@@ -36,7 +36,7 @@ nop
 %include "cdecl16.inc"
 %include "entry.inc"
 %include "config.inc"
-%include "mem.inc"
+%include "early_mem.inc"
 %include "error_codes.inc"
 %include "partition_table.inc"
 
@@ -136,7 +136,7 @@ main:
         push ax
         mov ax, DiskSig                         ; start of partition table
         push ax
-        mov ax, partition_table                 ; defined in memory.inc
+        mov ax, partition_table                 ; defined in early_mem.inc
         push ax
         call kmemcpy                            ; copy partition table to memory
         add sp, 0x6

--- a/src/mbr/mbr.nasm
+++ b/src/mbr/mbr.nasm
@@ -25,14 +25,11 @@
 [WARNING -reloc-abs-word]                   ; Yes, we use absolute addresses. surpress these warnings.
 [map all mbr.map]
 %define __STEVIA_MBR
-
 jmp short (init - $$)
 nop
 
 ; ###############
-;
 ; Headers/Includes/Definitions
-;
 ; ###############
 
 %include "util/bochs_magic.inc"
@@ -43,11 +40,7 @@ nop
 %include "error_codes.inc"
 %include "partition_table.inc"
 
-; ###############
-; End Section
-; ###############
-
-ALIGN 4, db 0x90
+ALIGN 4
 init:
     cli                         ; We do not want to be interrupted
 
@@ -69,23 +62,15 @@ init:
     jmp 0:main
 
 ; ###############
-;
 ; Extra/Shared Functions
-;
 ; ###############
 
 %include "util/kmem_func.nasm"
 %include "util/error_func.nasm"
 
-; ###############
-; End Section
-; ###############
-
 ;
 ; bp - 2 : uint8_t boot_drive
 ; bp - 4 : uint16_t part_offset
-;
-
 ALIGN 4, db 0x90
 main:
     mov byte [bp - 2], dl            ; BIOS passes drive number in DL
@@ -158,7 +143,7 @@ main:
 
         mov si, word [bp - 4]
         mov dl, byte [bp - 2]
-        jmp 0:0x7C00
+        jmp word 0x0000:0x7C00
 
 ; ###############
 ;
@@ -167,10 +152,6 @@ main:
 ; ###############
 
 %include 'BIOS/func/ext_read.nasm'
-
-; ###############
-; End Section
-; ###############
 
 %assign bytes_remaining (440 - ($ - $$))
 %warning MBR has bytes_remaining bytes remaining for code (MAX: 440 bytes)

--- a/src/stage2/stage2.nasm
+++ b/src/stage2/stage2.nasm
@@ -472,8 +472,24 @@ STAGE2_SIG: dd 0xDEADBEEF               ; Signature to mark the end of the stage
 section .bss follows=.sign
 align 512
 begin_bss:
-buffer1 resb 512
-buffer2 resb 512
-buffer3 resb 512
-buffer4 resb 512
+
+disk_buffer resb 512
+
+fat_buffer resb 512
+
+dir_buffer resb 512
+
+fat_fsinfo resb 512
+
+fat32_state resb FAT32_State_t_size
+
+%define BIOSMemoryMap_SIZE 4096
+BIOSMemoryMap resb 4096
+
+SteviaInfo resd 4
+
+align 16
+stack_bottom:
+    stack resb 4096
+stack_top:
 end_bss:

--- a/src/stage2/stage2.nasm
+++ b/src/stage2/stage2.nasm
@@ -396,27 +396,23 @@ ALIGN 16, db 0
 unreal_gdt_info:
     unreal_gdt_size: dw (unreal_gdt_end - unreal_gdt_start) - 1
     unreal_gdt_ptr:  dd ((__STAGE2_SEGMENT << 4) + unreal_gdt_start)
-
 unreal_gdt_start:
     ; entry 0 (null descriptor)
     dq 0                    ; first entry is null
 
     ; entry 1 (16-bit code segment with 4 GiB flat mapping)
-    dw 0xFFFF            ; Segment Limit 15:0
-    dw 0x0000            ; Base Address 15:0
-    db 0000_0000b        ; Base Address 23:16
-    
-    db 1001_1010b        ; Access Byte: executable, readable, present
-    db 1000_1111b        ; 24:20 G/DB/L/AVL & SegLimit 19:16
+    dq 0x0000FFFF        ; Base Address(15:0) 31:16, Segment Limit(15:0) 15:0
+    db 0x00              ; Base Address 23:16
+    db 1001_1010b        ; Access Byte: Present, ring0, S = 1, executable (1), non-conforming, readable, Accessed
+    db 1000_1111b        ; Flags: GR = 4KiB, attr = <DB/L/Avl>, Granularity = 4KiB & 16:19 of limit
     db 0000_0000b        ; Base Address 31:24
 
     ; entry 2 (16-bit data segment with 4 GiB flat mapping)
-    dw 0xFFFF            ; Segment Limit 15:0
-    dw 0x0000            ; Base Address 15:0
-    db 0000_0000b        ; Base Address 23:16
-    db 1001_0010b        ; Access Byte: readable, writable, present
-    db 1000_1111b        ; Flags: 16-bit, Granularity = 4KiB
-    db 0000_0000b        ; Base Address 31:24
+    dq 0x0000FFFF        ; Base Address(15:0) 31:16, Segment Limit(15:0) 15:0
+    db 0x00              ; Base Address(23:16)
+    db 1001_0010b        ; Access Byte: Present, ring0, S = 1, data (0), non-confirming, writable, present
+    db 1000_1111b        ; Flags: GR = 4KiB, attr = <16-bit/?/?>, Granularity = 4KiB & 16:19 of limit
+    db 0000_0000b        ; Base Address(31:24)
 unreal_gdt_end:
 
 ALIGN 16, db 0

--- a/src/vbr/vbr.nasm
+++ b/src/vbr/vbr.nasm
@@ -115,13 +115,12 @@ main:
     mov dword eax, 0x1
     push dword eax                                     ; lba
 
-    xor ax, ax
-    push ax                                            ; offset = 0
 
-    ; 07E0:0 = 0x00007e00
     mov ax, STAGE2_ENTRY
-    shr ax, 4
-    push ax                                            ; segment = 7E0
+    push ax                                            ; offset
+
+    xor ax, ax
+    push ax                                            ; segment = 0
 
     ; uint8_t read_stage2_raw(uint16_t buf_segment, uint16_t buf_offset, 
     ;                         uint32_t lba,
@@ -130,11 +129,8 @@ main:
     add sp, 0xC
 
 .check_sig:
-    ; BUG: this is hard coded to check @ ((0x7E0 << 4) + 0x7FFC)...i.e (STAGE2_ENTRY + (STAGE2_MAX_BYTES - 4))
-    ; this should be removed or done properly
-    mov ax, 0x7E0
-    mov fs, ax
-    cmp dword [fs:0x7FFC], 0xDEADBEEF
+    mov eax, dword [(MAX_STAGE2_BYTES - 4) + 0x500]
+    cmp eax, 0xDEADBEEF
     je main.sig_ok
 
     ERROR VBR_ERROR_NO_SIGNATURE          ; no signature present in stage2
@@ -142,7 +138,7 @@ main:
 .sig_ok:
     mov si, word [bp - 4]
     mov dl, byte [bp - 2]
-    jmp word 0x0000:0x7E00
+    jmp word 0x0000:STAGE2_ENTRY
 
 ; ###############
 ; Required BIOS function(s)

--- a/src/vbr/vbr.nasm
+++ b/src/vbr/vbr.nasm
@@ -47,7 +47,7 @@ times 54 db 0x00
 %include "cdecl16.inc"
 %include "entry.inc"
 %include "config.inc"
-%include "mem.inc"
+%include "early_mem.inc"
 %include "error_codes.inc"
 %include "fat32/bpb_offset_bx.inc"
 


### PR DESCRIPTION
convert MBR, VBR, & Stage2 to use a BSS section. also pass some of the data we load that is important later (partition table, bpb, ebpb) to stage2. memory.inc no longer contains defines with the intended offset in the current segment, all memory locations have been define in the bss and replaced with struc definitions to simplify creation of some of these structures.